### PR TITLE
fix(feed): 댓글 임의로 로딩 복구

### DIFF
--- a/services/feed/src/pages/comment/[postId]/index.tsx
+++ b/services/feed/src/pages/comment/[postId]/index.tsx
@@ -7,7 +7,7 @@ import { useComment } from '../../../comment/hooks/useComment';
 import useFeedList from '../../../main/hooks/useFeedList';
 import { useRouter } from 'next/router';
 import SubmitTextarea from '../../../common/components/SubmitTextarea';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import useAddComments from '../../../comment/hooks/useAddComment';
 import { ImageCountContainer } from '../../../common/components/image';
 import { useScrollWithRef } from '../../../write/hooks/useScrollWithRef';
@@ -19,9 +19,13 @@ const Comment = () => {
     const postId = router.query.postId as string;
     const [commentValue, setCommentValue] = useState('');
     const { data: commentsData } = useComment();
-    const { data: feedsData, isLoading } = useFeedList(postId);
+    const { data: feedsData, refetch, isLoading } = useFeedList(postId);
     const { mutate: addMutate } = useAddComments(postId);
     const { ref, isScroll } = useScrollWithRef();
+
+    useEffect(() => {
+        if (feedsData == null) refetch();
+    }, [isLoading])
 
     return (
         <>


### PR DESCRIPTION
일단 댓글 복구하기 위해서 PR 올립니다
직접 URL로 들어가게 되면, useRouter()가 ready되기 전에 호출되어 postId가 undefined가 됩니다.
이를 일시적으로 해결한 것 뿐이라서, 콘솔 확인시 Error(404)는 그대로 보여집니다